### PR TITLE
feat: restructure OpenCRE data with verified per-CWE mapping files

### DIFF
--- a/data/opencre/CWE-16.md
+++ b/data/opencre/CWE-16.md
@@ -1,0 +1,48 @@
+---
+title: "CWE-16 Configuration"
+cwe_id: "CWE-16"
+owasp_top10: "A05:2021 Security Misconfiguration"
+opencre_mappings:
+  - cre_id: "180-488"
+    cre_name: "Proper Configuration for all applications and frameworks"
+  - cre_id: "462-245"
+    cre_name: "Remove unnecessary elements from external components"
+  - cre_id: "623-347"
+    cre_name: "Disallow shared high privileged accounts"
+when_to_use:
+  - reviewing application and framework configurations
+  - assessing production deployments for debug settings
+  - evaluating security headers and CORS policies
+  - auditing default credentials and unnecessary features
+threats:
+  - default credentials left in production
+  - debug mode or verbose errors enabled in production
+  - overly permissive CORS configurations
+  - missing security headers
+  - unnecessary features or admin panels exposed
+summary: "Security misconfiguration occurs when applications, frameworks, or infrastructure use insecure defaults, unnecessary features, or improperly configured security controls."
+---
+
+# CWE-16: Configuration
+
+## OpenCRE Mappings
+
+| CRE ID | CRE Name | Link |
+|--------|----------|------|
+| 180-488 | Proper Configuration for all applications and frameworks | [opencre.org/cre/180-488](https://www.opencre.org/cre/180-488) |
+| 462-245 | Remove unnecessary elements from external components | [opencre.org/cre/462-245](https://www.opencre.org/cre/462-245) |
+| 623-347 | Disallow shared high privileged accounts | [opencre.org/cre/623-347](https://www.opencre.org/cre/623-347) |
+
+## What to Look For
+
+- Default credentials or sample configurations in production
+- Debug endpoints, admin panels, or development tools exposed
+- Missing security headers (X-Content-Type-Options, Strict-Transport-Security, etc.)
+- Overly permissive CORS (Access-Control-Allow-Origin: *)
+- Directory listing enabled
+- Missing rate limiting on sensitive endpoints
+
+## References
+
+- [CWE-16](https://cwe.mitre.org/data/definitions/16.html)
+- [OWASP Security Headers](https://owasp.org/www-project-secure-headers/)

--- a/data/opencre/CWE-200.md
+++ b/data/opencre/CWE-200.md
@@ -1,0 +1,48 @@
+---
+title: "CWE-200 Exposure of Sensitive Information"
+cwe_id: "CWE-200"
+owasp_top10: "A01:2021 Broken Access Control"
+opencre_mappings:
+  - cre_id: "713-683"
+    cre_name: "Protect logs against unauthorized access"
+  - cre_id: "743-110"
+    cre_name: "Do not disclose technical information in HTTP header or response"
+  - cre_id: "227-045"
+    cre_name: "Identify sensitive data and subject it to a policy"
+when_to_use:
+  - reviewing error handling for information leakage
+  - assessing API responses for over-exposure of data
+  - evaluating logging for sensitive data capture
+  - auditing LLM outputs for unintended data disclosure
+threats:
+  - sensitive data in error messages or stack traces
+  - verbose API responses including unnecessary fields
+  - credentials or PII in application logs
+  - debug mode enabled in production
+  - LLM training data memorization and disclosure
+summary: "Sensitive information exposure occurs when applications inadvertently reveal data that can be used by attackers — through error messages, logs, API responses, or verbose configurations."
+---
+
+# CWE-200: Exposure of Sensitive Information
+
+## OpenCRE Mappings
+
+| CRE ID | CRE Name | Link |
+|--------|----------|------|
+| 713-683 | Protect logs against unauthorized access | [opencre.org/cre/713-683](https://www.opencre.org/cre/713-683) |
+| 743-110 | Do not disclose technical info in HTTP headers | [opencre.org/cre/743-110](https://www.opencre.org/cre/743-110) |
+| 227-045 | Identify sensitive data and subject it to a policy | [opencre.org/cre/227-045](https://www.opencre.org/cre/227-045) |
+
+## What to Look For
+
+- Stack traces or internal paths in error responses
+- Verbose logging of requests/responses containing PII
+- Missing response headers (X-Content-Type-Options, etc.)
+- API responses including more fields than necessary
+- Debug mode enabled in production configs
+- LLM outputs containing memorized training data
+
+## References
+
+- [CWE-200](https://cwe.mitre.org/data/definitions/200.html)
+- [OWASP Error Handling Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Error_Handling_Cheat_Sheet.html)

--- a/data/opencre/CWE-22.md
+++ b/data/opencre/CWE-22.md
@@ -1,0 +1,40 @@
+---
+title: "CWE-22 Path Traversal"
+cwe_id: "CWE-22"
+owasp_top10: "A01:2021 Broken Access Control"
+opencre_mappings:
+  - cre_id: "675-168"
+    cre_name: "Sanitize filename metadata from untrusted origin if processing is required"
+when_to_use:
+  - reviewing file upload or download functionality
+  - assessing user-supplied file paths in application code
+  - evaluating MCP server tools that access the filesystem
+  - auditing LLM agent tools that read or write files
+threats:
+  - directory traversal via ../ sequences in file paths
+  - arbitrary file read via path manipulation
+  - local file inclusion (LFI) via controlled path input
+  - zip slip attacks via malicious archive extraction
+summary: "Path traversal occurs when user-controlled input is used to construct file paths without canonicalization, allowing access to files outside intended directories."
+---
+
+# CWE-22: Path Traversal
+
+## OpenCRE Mappings
+
+| CRE ID | CRE Name | Link |
+|--------|----------|------|
+| 675-168 | Sanitize filename metadata from untrusted origin | [opencre.org/cre/675-168](https://www.opencre.org/cre/675-168) |
+
+## What to Look For
+
+- User input in file path construction without canonicalization
+- Missing validation for `../` sequences or null bytes in file paths
+- File operations using user-supplied filenames directly
+- Archive extraction without path validation (zip slip)
+- MCP server or LLM agent tools that accept file paths from model output
+
+## References
+
+- [CWE-22](https://cwe.mitre.org/data/definitions/22.html)
+- [OWASP Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)

--- a/data/opencre/CWE-287.md
+++ b/data/opencre/CWE-287.md
@@ -1,0 +1,48 @@
+---
+title: "CWE-287 Improper Authentication"
+cwe_id: "CWE-287"
+owasp_top10: "A07:2021 Identification and Authentication Failures"
+opencre_mappings:
+  - cre_id: "813-610"
+    cre_name: "Do not use static secrets"
+  - cre_id: "605-735"
+    cre_name: "Authenticate all external connections"
+  - cre_id: "816-631"
+    cre_name: "Ensure timely expiration of out of band authentication request, code, or tokens"
+when_to_use:
+  - reviewing authentication mechanisms (login, API auth, JWT)
+  - assessing password policies and credential storage
+  - evaluating MFA implementations
+  - auditing API key and token management
+threats:
+  - authentication bypass via logic flaws
+  - credential stuffing and brute force attacks
+  - JWT algorithm confusion or weak signing
+  - missing authentication on API endpoints
+  - static secrets and hardcoded credentials
+summary: "Improper authentication allows attackers to bypass identity verification, impersonate users, or access protected resources without valid credentials."
+---
+
+# CWE-287: Improper Authentication
+
+## OpenCRE Mappings
+
+| CRE ID | CRE Name | Link |
+|--------|----------|------|
+| 813-610 | Do not use static secrets | [opencre.org/cre/813-610](https://www.opencre.org/cre/813-610) |
+| 605-735 | Authenticate all external connections | [opencre.org/cre/605-735](https://www.opencre.org/cre/605-735) |
+| 816-631 | Ensure timely expiration of OOB auth tokens | [opencre.org/cre/816-631](https://www.opencre.org/cre/816-631) |
+
+## What to Look For
+
+- Missing authentication on endpoints or functions
+- Hardcoded credentials or API keys
+- JWT issues: `none` algorithm, missing expiry, weak signing key, secrets in payload
+- Weak password requirements or missing rate limiting on login
+- Missing MFA enforcement for sensitive operations
+- Session tokens in URLs or logs
+
+## References
+
+- [CWE-287](https://cwe.mitre.org/data/definitions/287.html)
+- [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)

--- a/data/opencre/CWE-327.md
+++ b/data/opencre/CWE-327.md
@@ -1,0 +1,48 @@
+---
+title: "CWE-327 Use of a Broken or Risky Cryptographic Algorithm"
+cwe_id: "CWE-327"
+owasp_top10: "A02:2021 Cryptographic Failures"
+opencre_mappings:
+  - cre_id: "742-431"
+    cre_name: "Use approved cryptographic algorithms"
+  - cre_id: "002-801"
+    cre_name: "Use approved cryptographic algorithms for generation, seeding and verification"
+  - cre_id: "504-340"
+    cre_name: "Encrypt sensitive data with algorithms that provide both confidentiality and integrity"
+when_to_use:
+  - reviewing cryptographic implementations
+  - assessing password hashing algorithms
+  - evaluating encryption at rest and in transit configurations
+  - auditing key management practices
+threats:
+  - weak algorithms (MD5, SHA1 for passwords, DES, RC4)
+  - ECB mode usage leaking patterns
+  - hardcoded encryption keys or IVs
+  - insufficient key lengths (RSA < 2048, AES < 128)
+  - custom cryptographic implementations
+summary: "Use of broken or risky cryptographic algorithms undermines data confidentiality and integrity, allowing attackers to decrypt, forge, or tamper with protected data."
+---
+
+# CWE-327: Use of a Broken or Risky Cryptographic Algorithm
+
+## OpenCRE Mappings
+
+| CRE ID | CRE Name | Link |
+|--------|----------|------|
+| 742-431 | Use approved cryptographic algorithms | [opencre.org/cre/742-431](https://www.opencre.org/cre/742-431) |
+| 002-801 | Use approved algorithms for generation, seeding and verification | [opencre.org/cre/002-801](https://www.opencre.org/cre/002-801) |
+| 504-340 | Encrypt with algorithms providing confidentiality and integrity | [opencre.org/cre/504-340](https://www.opencre.org/cre/504-340) |
+
+## What to Look For
+
+- MD5 or SHA1 used for password hashing (use bcrypt, scrypt, or Argon2)
+- DES, 3DES, RC4, or Blowfish in production code
+- ECB mode usage (use GCM or CBC with HMAC)
+- Hardcoded encryption keys, IVs, or salts
+- RSA keys < 2048 bits or AES keys < 128 bits
+- Custom cryptographic implementations instead of vetted libraries
+
+## References
+
+- [CWE-327](https://cwe.mitre.org/data/definitions/327.html)
+- [OWASP Cryptographic Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)

--- a/data/opencre/CWE-352.md
+++ b/data/opencre/CWE-352.md
@@ -1,0 +1,41 @@
+---
+title: "CWE-352 Cross-Site Request Forgery (CSRF)"
+cwe_id: "CWE-352"
+owasp_top10: "A01:2021 Broken Access Control"
+opencre_mappings:
+  - cre_id: "464-084"
+    cre_name: "Add CSRF protection for cookie based REST services"
+  - cre_id: "060-472"
+    cre_name: "Use CSRF protection against authenticated functionality"
+when_to_use:
+  - reviewing state-changing endpoints for CSRF protection
+  - assessing cookie-based authentication for CSRF risks
+  - evaluating SameSite cookie attributes
+  - auditing form submissions and API mutations
+threats:
+  - unauthorized state changes via forged cross-origin requests
+  - CSRF on admin functionality leading to privilege escalation
+  - CSRF bypasses via misconfigured SameSite attributes
+summary: "CSRF forces authenticated users to submit unintended requests, enabling attackers to perform state-changing actions on behalf of victims."
+---
+
+# CWE-352: Cross-Site Request Forgery (CSRF)
+
+## OpenCRE Mappings
+
+| CRE ID | CRE Name | Link |
+|--------|----------|------|
+| 464-084 | Add CSRF protection for cookie based REST services | [opencre.org/cre/464-084](https://www.opencre.org/cre/464-084) |
+| 060-472 | Use CSRF protection against authenticated functionality | [opencre.org/cre/060-472](https://www.opencre.org/cre/060-472) |
+
+## What to Look For
+
+- State-changing operations without CSRF tokens
+- Missing SameSite cookie attribute or set to `None`
+- CORS misconfiguration allowing cross-origin requests with credentials
+- Framework CSRF middleware disabled or exempted on sensitive routes
+
+## References
+
+- [CWE-352](https://cwe.mitre.org/data/definitions/352.html)
+- [OWASP CSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)

--- a/data/opencre/CWE-384.md
+++ b/data/opencre/CWE-384.md
@@ -1,0 +1,38 @@
+---
+title: "CWE-384 Session Fixation"
+cwe_id: "CWE-384"
+owasp_top10: "A07:2021 Identification and Authentication Failures"
+opencre_mappings:
+  - cre_id: "002-630"
+    cre_name: "Generate a new session token after authentication"
+when_to_use:
+  - reviewing session management implementations
+  - assessing login flows for session regeneration
+  - evaluating cookie security attributes
+  - auditing authentication state transitions
+threats:
+  - session fixation via pre-set session tokens
+  - session hijacking after authentication without regeneration
+  - session tokens persisted across privilege changes
+summary: "Session fixation allows attackers to set a victim's session identifier before authentication, then hijack the authenticated session."
+---
+
+# CWE-384: Session Fixation
+
+## OpenCRE Mappings
+
+| CRE ID | CRE Name | Link |
+|--------|----------|------|
+| 002-630 | Generate a new session token after authentication | [opencre.org/cre/002-630](https://www.opencre.org/cre/002-630) |
+
+## What to Look For
+
+- Missing session ID regeneration after login
+- Session tokens unchanged after privilege escalation
+- Accepting session IDs from URL parameters or form fields
+- Missing session invalidation on logout or password change
+
+## References
+
+- [CWE-384](https://cwe.mitre.org/data/definitions/384.html)
+- [OWASP Session Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html)

--- a/data/opencre/CWE-502.md
+++ b/data/opencre/CWE-502.md
@@ -1,0 +1,45 @@
+---
+title: "CWE-502 Deserialization of Untrusted Data"
+cwe_id: "CWE-502"
+owasp_top10: "A08:2021 Software and Data Integrity Failures"
+opencre_mappings:
+  - cre_id: "831-563"
+    cre_name: "Avoid deserialization logic"
+  - cre_id: "736-554"
+    cre_name: "Block serialization of content from untrusted clients"
+  - cre_id: "762-616"
+    cre_name: "Secure serialized objects (e.g. integrity checks)"
+when_to_use:
+  - reviewing code that deserializes data from untrusted sources
+  - assessing API endpoints that accept serialized objects
+  - evaluating ML model loading for unsafe deserialization
+  - auditing cookie or token deserialization logic
+threats:
+  - remote code execution via malicious serialized payloads
+  - object injection via manipulated serialized data
+  - denial of service via crafted deserialization payloads
+  - ML model tampering via malicious serialized model files
+summary: "Deserialization of untrusted data can lead to remote code execution, object injection, or denial of service when applications reconstruct objects from attacker-controlled serialized input."
+---
+
+# CWE-502: Deserialization of Untrusted Data
+
+## OpenCRE Mappings
+
+| CRE ID | CRE Name | Link |
+|--------|----------|------|
+| 831-563 | Avoid deserialization logic | [opencre.org/cre/831-563](https://www.opencre.org/cre/831-563) |
+| 736-554 | Block serialization of content from untrusted clients | [opencre.org/cre/736-554](https://www.opencre.org/cre/736-554) |
+| 762-616 | Secure serialized objects (integrity checks) | [opencre.org/cre/762-616](https://www.opencre.org/cre/762-616) |
+
+## What to Look For
+
+- Native deserialization of untrusted input (Java ObjectInputStream, Python unpickling, PHP unserialize, Ruby Marshal, .NET BinaryFormatter)
+- Missing integrity checks on serialized data (unsigned cookies or tokens)
+- ML model files loaded without verification
+- Missing CSRF protection on state-changing operations using serialized payloads
+
+## References
+
+- [CWE-502](https://cwe.mitre.org/data/definitions/502.html)
+- [OWASP Deserialization Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html)

--- a/data/opencre/CWE-778.md
+++ b/data/opencre/CWE-778.md
@@ -1,0 +1,46 @@
+---
+title: "CWE-778 Insufficient Logging"
+cwe_id: "CWE-778"
+owasp_top10: "A09:2021 Security Logging and Monitoring Failures"
+opencre_mappings:
+  - cre_id: "184-284"
+    cre_name: "Log all security relevant events"
+  - cre_id: "841-710"
+    cre_name: "Log authentication decisions without exposing sensitive data"
+  - cre_id: "555-048"
+    cre_name: "Log events sufficiently to recreate their order"
+when_to_use:
+  - reviewing logging implementations for security events
+  - assessing audit trail completeness
+  - evaluating log protection and integrity
+  - auditing incident response readiness
+threats:
+  - undetected breaches due to missing security event logs
+  - tampered logs destroying forensic evidence
+  - sensitive data exposure in verbose log entries
+  - insufficient monitoring delaying incident response
+summary: "Insufficient logging prevents detection of security breaches, hinders forensic analysis, and delays incident response when critical security events go unrecorded."
+---
+
+# CWE-778: Insufficient Logging
+
+## OpenCRE Mappings
+
+| CRE ID | CRE Name | Link |
+|--------|----------|------|
+| 184-284 | Log all security relevant events | [opencre.org/cre/184-284](https://www.opencre.org/cre/184-284) |
+| 841-710 | Log authentication decisions without exposing sensitive data | [opencre.org/cre/841-710](https://www.opencre.org/cre/841-710) |
+| 555-048 | Log events sufficiently to recreate their order | [opencre.org/cre/555-048](https://www.opencre.org/cre/555-048) |
+
+## What to Look For
+
+- Missing logs for authentication successes and failures
+- No audit trail for authorization decisions or privilege changes
+- Sensitive data (passwords, tokens, PII) in log entries
+- Logs without timestamps, user IDs, or source IPs
+- Missing log integrity protections (append-only, centralized collection)
+
+## References
+
+- [CWE-778](https://cwe.mitre.org/data/definitions/778.html)
+- [OWASP Logging Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)

--- a/data/opencre/CWE-78.md
+++ b/data/opencre/CWE-78.md
@@ -1,0 +1,43 @@
+---
+title: "CWE-78 OS Command Injection"
+cwe_id: "CWE-78"
+owasp_top10: "A03:2021 Injection"
+opencre_mappings:
+  - cre_id: "857-718"
+    cre_name: "Protect against OS command injection attack"
+  - cre_id: "683-722"
+    cre_name: "Block direct execution of file metadata from untrusted origin"
+when_to_use:
+  - reviewing code that invokes shell commands or system processes
+  - assessing LLM agents that run tools via shell
+  - evaluating CI/CD pipelines for command injection risks
+  - auditing MCP server tools that run system commands
+threats:
+  - command injection via unsanitized user input in shell calls
+  - argument injection via special characters in command parameters
+  - command injection via LLM-generated tool invocations
+  - indirect injection via filenames or metadata containing shell metacharacters
+summary: "OS command injection occurs when untrusted data is passed to system shell commands without proper sanitization, allowing attackers to run arbitrary commands."
+---
+
+# CWE-78: OS Command Injection
+
+## OpenCRE Mappings
+
+| CRE ID | CRE Name | Link |
+|--------|----------|------|
+| 857-718 | Protect against OS command injection attack | [opencre.org/cre/857-718](https://www.opencre.org/cre/857-718) |
+| 683-722 | Block direct file metadata execution from untrusted origin | [opencre.org/cre/683-722](https://www.opencre.org/cre/683-722) |
+
+## What to Look For
+
+- User input in system(), popen(), or subprocess calls without sanitization
+- Shell interpolation of variables in command strings
+- Missing use of array-based process invocation (safer than shell strings)
+- LLM agent tools that construct shell commands from model output
+- MCP server tools accepting free-form command parameters
+
+## References
+
+- [CWE-78](https://cwe.mitre.org/data/definitions/78.html)
+- [OWASP OS Command Injection Defense Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html)

--- a/data/opencre/CWE-79.md
+++ b/data/opencre/CWE-79.md
@@ -1,0 +1,48 @@
+---
+title: "CWE-79 Cross-site Scripting (XSS)"
+cwe_id: "CWE-79"
+owasp_top10: "A03:2021 Injection"
+opencre_mappings:
+  - cre_id: "366-835"
+    cre_name: "Escape output against XSS"
+when_to_use:
+  - reviewing code that renders user input in HTML pages
+  - assessing template engines for auto-escaping behavior
+  - evaluating client-side JavaScript for DOM-based XSS
+  - auditing LLM output rendered in web interfaces
+threats:
+  - reflected XSS via URL parameters or form inputs
+  - stored XSS via database-persisted user content
+  - DOM-based XSS via client-side JavaScript
+  - XSS via LLM-generated HTML or Markdown
+summary: "Cross-site scripting occurs when untrusted data is included in web output without proper encoding, allowing attackers to run scripts in victim browsers."
+---
+
+# CWE-79: Cross-site Scripting (XSS)
+
+## OpenCRE Mappings
+
+| CRE ID | CRE Name | Link |
+|--------|----------|------|
+| 366-835 | Escape output against XSS | [opencre.org/cre/366-835](https://www.opencre.org/cre/366-835) |
+
+## Cross-Standard References
+
+Via OpenCRE 366-835:
+- **ASVS**: V5.3.3 — Verify context-aware output encoding
+- **WSTG**: WSTG-INPV-01 — Testing for Reflected XSS
+- **OWASP Cheat Sheet**: XSS Prevention
+- **NIST 800-53**: SI-10 — Information Input Validation
+
+## What to Look For
+
+- User input rendered without output encoding in HTML, JavaScript, CSS, or URL contexts
+- Template engines with auto-escaping disabled or bypassed (safe filters, raw output, unsafe HTML rendering props)
+- DOM manipulation using innerHTML or unsafe DOM write methods with user data
+- LLM-generated Markdown or HTML rendered without sanitization
+- Missing Content-Security-Policy headers
+
+## References
+
+- [CWE-79](https://cwe.mitre.org/data/definitions/79.html)
+- [OWASP XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Scripting_Prevention_Cheat_Sheet.html)

--- a/data/opencre/CWE-798.md
+++ b/data/opencre/CWE-798.md
@@ -1,0 +1,46 @@
+---
+title: "CWE-798 Use of Hard-coded Credentials"
+cwe_id: "CWE-798"
+owasp_top10: "A07:2021 Identification and Authentication Failures"
+opencre_mappings:
+  - cre_id: "551-054"
+    cre_name: "Use ephemeral secrets rather than static secrets"
+  - cre_id: "774-888"
+    cre_name: "Do not store secrets in the code"
+  - cre_id: "340-375"
+    cre_name: "Use a dedicated secrets management solution"
+when_to_use:
+  - scanning code for hardcoded credentials or API keys
+  - reviewing configuration files for embedded secrets
+  - assessing secrets management practices
+  - auditing LLM system prompts for embedded credentials
+threats:
+  - credential exposure via source code repositories
+  - API key leakage in client-side code or configs
+  - secrets in system prompts extractable via prompt injection
+  - shared credentials enabling lateral movement
+summary: "Hard-coded credentials in source code, configuration files, or system prompts can be extracted by attackers to gain unauthorized access to systems and services."
+---
+
+# CWE-798: Use of Hard-coded Credentials
+
+## OpenCRE Mappings
+
+| CRE ID | CRE Name | Link |
+|--------|----------|------|
+| 551-054 | Use ephemeral secrets rather than static secrets | [opencre.org/cre/551-054](https://www.opencre.org/cre/551-054) |
+| 774-888 | Do not store secrets in the code | [opencre.org/cre/774-888](https://www.opencre.org/cre/774-888) |
+| 340-375 | Use a dedicated secrets management solution | [opencre.org/cre/340-375](https://www.opencre.org/cre/340-375) |
+
+## What to Look For
+
+- API keys, passwords, or tokens in source code or configs
+- Connection strings with embedded credentials
+- Private keys or certificates committed to repositories
+- Credentials in LLM system prompts or CLAUDE.md files
+- High-risk files: .env, docker-compose, *.tfvars, terraform.tfstate, kubeconfig
+
+## References
+
+- [CWE-798](https://cwe.mitre.org/data/definitions/798.html)
+- [OWASP Secrets Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html)

--- a/data/opencre/CWE-89.md
+++ b/data/opencre/CWE-89.md
@@ -1,0 +1,51 @@
+---
+title: "CWE-89 SQL Injection"
+cwe_id: "CWE-89"
+owasp_top10: "A03:2021 Injection"
+opencre_mappings:
+  - cre_id: "064-808"
+    cre_name: "Encode output context-specifically"
+  - cre_id: "732-873"
+    cre_name: "Lock/precompile queries (parameterization) to avoid injection attacks"
+when_to_use:
+  - reviewing database query construction in application code
+  - assessing ORM usage for raw query patterns
+  - evaluating stored procedures or dynamic SQL
+  - auditing LLM-generated SQL queries
+threats:
+  - SQL injection via string concatenation in queries
+  - second-order SQL injection via stored data
+  - blind SQL injection via boolean or time-based inference
+  - SQL injection via LLM-generated queries
+summary: "SQL injection occurs when untrusted data is sent to a database interpreter as part of a query, allowing attackers to read, modify, or delete data."
+---
+
+# CWE-89: SQL Injection
+
+## OpenCRE Mappings
+
+| CRE ID | CRE Name | Link |
+|--------|----------|------|
+| 064-808 | Encode output context-specifically | [opencre.org/cre/064-808](https://www.opencre.org/cre/064-808) |
+| 732-873 | Lock/precompile queries (parameterization) | [opencre.org/cre/732-873](https://www.opencre.org/cre/732-873) |
+
+## Cross-Standard References
+
+Via OpenCRE 732-873:
+- **ASVS**: V5.3.4 — Verify parameterized queries or ORM usage
+- **WSTG**: WSTG-INPV-05 — Testing for SQL Injection
+- **OWASP Cheat Sheet**: SQL Injection Prevention
+- **NIST 800-53**: SI-10 — Information Input Validation
+
+## What to Look For
+
+- String concatenation or interpolation in SQL queries
+- ORM raw query methods (`raw()`, `execute()`, `$queryRaw`)
+- Missing parameterized queries or prepared statements
+- Dynamic table/column names from user input
+- LLM output passed directly to database query functions
+
+## References
+
+- [CWE-89](https://cwe.mitre.org/data/definitions/89.html)
+- [OWASP SQL Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)

--- a/data/opencre/README.md
+++ b/data/opencre/README.md
@@ -1,29 +1,71 @@
-# OpenCRE — Cross-Standard Reference Layer
+# OpenCRE — Cross-Standard Reference Data
+
+12 structured CWE-to-CRE mapping files with verified OpenCRE IDs, plus API documentation for lookups.
 
 [OpenCRE](https://www.opencre.org) (Open Common Requirements Enumeration) maps security requirements across standards, creating a unified graph that links CWEs, OWASP projects, NIST, ISO 27001, and more.
 
-## Why OpenCRE
+## Source & License
 
-When a finding references CWE-79, OpenCRE tells you which ASVS requirement covers it (V5.3.3), which WSTG test to run (WSTG-INPV-01), which OWASP cheat sheet applies (XSS Prevention), and which NIST 800-53 control maps to it — all through a single lookup.
+OpenCRE is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0). CRE IDs were verified against the OpenCRE REST API (`GET /rest/v1/standard/CWE/sectionid/{id}`).
 
-This eliminates manual cross-referencing between standards and ensures findings are traceable across compliance frameworks.
+## File Format
 
-## Standards Mapped
+Each file has YAML frontmatter with:
 
-| Standard | Coverage |
-|----------|----------|
-| CWE | Common Weakness Enumeration (944 weaknesses) |
-| OWASP Top 10 (2021) | A01-A10 |
-| OWASP ASVS | Application Security Verification Standard |
-| OWASP WSTG | Web Security Testing Guide |
-| OWASP Proactive Controls | C1-C10 |
-| OWASP Cheat Sheets | Per-topic defense guidance |
-| NIST 800-53 v5 | Security and Privacy Controls |
-| NIST SSDF | Secure Software Development Framework |
-| ISO 27001 | Information Security Management |
-| CAPEC | Common Attack Pattern Enumeration |
-| Cloud Controls Matrix | CSA CCM |
-| OWASP SAMM | Software Assurance Maturity Model |
+```yaml
+---
+title: "CWE-79 Cross-site Scripting (XSS)"
+cwe_id: "CWE-79"
+owasp_top10: "A03:2021 Injection"
+opencre_mappings:                         # Verified CRE IDs from API
+  - cre_id: "366-835"
+    cre_name: "Escape output against XSS"
+when_to_use:                              # Task-matching triggers
+  - reviewing code that renders user input in HTML pages
+threats:                                  # Relevant threat categories
+  - reflected XSS via URL parameters
+summary: "Brief description."
+---
+```
+
+Followed by OpenCRE mapping table, cross-standard references, "What to Look For" checklist, and external references.
+
+## Usage in Skills
+
+### Finding Cross-References
+
+When producing a finding, look up the CWE file to get the verified CRE ID:
+
+```markdown
+- **CWE**: CWE-79
+- **OpenCRE**: [366-835](https://www.opencre.org/cre/366-835) — Escape output against XSS
+```
+
+The OpenCRE link gives readers one-click access to every related standard, cheat sheet, and test case.
+
+### Task-Based Lookup
+
+Use the `when_to_use` frontmatter to match tasks to relevant CWE/CRE mappings. For example, if reviewing file upload code, check:
+- `CWE-22` — Path Traversal
+- `CWE-502` — Deserialization of Untrusted Data
+
+## CWE Mapping Index
+
+| File | CWE | OWASP Top 10 | Primary CRE ID | CRE Name |
+|------|-----|-------------|----------------|----------|
+| [CWE-79](CWE-79.md) | CWE-79 | A03 Injection | 366-835 | Escape output against XSS |
+| [CWE-89](CWE-89.md) | CWE-89 | A03 Injection | 732-873 | Lock/precompile queries (parameterization) |
+| [CWE-78](CWE-78.md) | CWE-78 | A03 Injection | 857-718 | Protect against OS command injection |
+| [CWE-22](CWE-22.md) | CWE-22 | A01 Broken Access Control | 675-168 | Sanitize filename metadata from untrusted origin |
+| [CWE-287](CWE-287.md) | CWE-287 | A07 Auth Failures | 813-610 | Do not use static secrets |
+| [CWE-200](CWE-200.md) | CWE-200 | A01 Broken Access Control | 227-045 | Identify sensitive data and subject it to a policy |
+| [CWE-327](CWE-327.md) | CWE-327 | A02 Cryptographic Failures | 742-431 | Use approved cryptographic algorithms |
+| [CWE-352](CWE-352.md) | CWE-352 | A01 Broken Access Control | 464-084 | Add CSRF protection for cookie based REST services |
+| [CWE-384](CWE-384.md) | CWE-384 | A07 Auth Failures | 002-630 | Generate a new session token after authentication |
+| [CWE-502](CWE-502.md) | CWE-502 | A08 Data Integrity | 831-563 | Avoid deserialization logic |
+| [CWE-778](CWE-778.md) | CWE-778 | A09 Logging Failures | 184-284 | Log all security relevant events |
+| [CWE-798](CWE-798.md) | CWE-798 | A07 Auth Failures | 774-888 | Do not store secrets in the code |
+| [CWE-16](CWE-16.md) | CWE-16 | A05 Misconfiguration | 180-488 | Proper Configuration for all apps and frameworks |
 
 ## CRE Hierarchy
 
@@ -37,96 +79,40 @@ OpenCRE organizes security into five root domains:
 | 862-452 | Operating processes for security |
 | 567-755 | Governance processes for security |
 
-Under **Technical application security controls** (636-660):
-
-| CRE ID | Category |
-|--------|----------|
-| 633-428 | Authentication |
-| 724-770 | Technical application access control |
-| 503-455 | Input and output protection |
-| 842-876 | Logging and error handling |
-| 854-643 | Robust business logic |
-| 278-646 | Secure communication |
-| 126-668 | Secure data storage |
-| 708-355 | Secure implemented architecture |
-| 586-842 | Secure user management |
-| 177-260 | Session management |
-| 233-748 | Configuration hardening |
-
 ## REST API
 
 Base URL: `https://www.opencre.org/rest/v1`
 
-### Lookup by CRE ID
+| Endpoint | Description | Example |
+|----------|-------------|---------|
+| `GET /id/{cre-id}` | Lookup by CRE ID | `/id/366-835` |
+| `GET /standard/{name}/sectionid/{id}` | Lookup by standard | `/standard/CWE/sectionid/79` |
+| `GET /root_cres` | Get all root categories | `/root_cres` |
 
-```
-GET /id/{cre-id}
-```
+Web UI: `https://www.opencre.org/cre/{cre-id}`
 
-Example: `GET /id/366-835` returns the "Escape output against XSS" CRE with all linked standards.
+## Standards Mapped
 
-### Lookup by Standard
+| Standard | Coverage |
+|----------|----------|
+| CWE | Common Weakness Enumeration |
+| OWASP Top 10 (2021) | A01-A10 |
+| OWASP ASVS | Application Security Verification Standard |
+| OWASP WSTG | Web Security Testing Guide |
+| OWASP Proactive Controls | C1-C10 |
+| OWASP Cheat Sheets | Per-topic defense guidance |
+| NIST 800-53 v5 | Security and Privacy Controls |
+| NIST SSDF | Secure Software Development Framework |
+| ISO 27001 | Information Security Management |
+| CAPEC | Common Attack Pattern Enumeration |
 
-```
-GET /standard/{standard-name}/sectionid/{section-id}
-```
+## Adding New Mappings
 
-Example: `GET /standard/CWE/sectionid/79` returns CREs linked to CWE-79.
+To add a CWE not listed here:
 
-### Get Root CREs
-
-```
-GET /root_cres
-```
-
-Returns all top-level CRE categories.
-
-### Web UI
-
-For any CRE, the web link is:
-
-```
-https://www.opencre.org/cre/{cre-id}
-```
-
-For any standard mapping:
-
-```
-https://www.opencre.org/standard/{standard-name}/{section-id}
+```bash
+# Look up the CWE in OpenCRE API
+curl -s "https://www.opencre.org/rest/v1/standard/CWE/sectionid/XXX" | jq '.data[].links[].document | select(.doctype == "CRE") | {id, name}'
 ```
 
-## Usage in Findings
-
-When producing a finding, include the OpenCRE link to enable cross-standard traceability:
-
-```markdown
-### [HIGH] Reflected XSS in Search Parameter
-
-- **CWE**: CWE-79
-- **OpenCRE**: [366-835](https://www.opencre.org/cre/366-835) — Escape output against XSS
-- **OWASP Ref**: Top 10 A03, ASVS V5.3.3, WSTG-INPV-01
-- **Location**: src/search.js:42
-```
-
-The OpenCRE link gives the reader one-click access to every related standard, cheat sheet, and test case.
-
-## Common CRE Mappings for Playbook Skills
-
-These are the CREs most frequently relevant to our plays:
-
-| Finding Type | CWE | CRE ID | CRE Name |
-|-------------|-----|--------|----------|
-| XSS | CWE-79 | 366-835 | Escape output against XSS |
-| SQL Injection | CWE-89 | 161-451 | Output encoding and injection prevention |
-| Command Injection | CWE-78 | 161-451 | Output encoding and injection prevention |
-| Broken Access Control | CWE-862 | 724-770 | Technical application access control |
-| Auth Bypass | CWE-287 | 633-428 | Authentication |
-| Sensitive Data Exposure | CWE-200 | 126-668 | Secure data storage |
-| CSRF | CWE-352 | 854-643 | Robust business logic |
-| Path Traversal | CWE-22 | 503-455 | Input and output protection |
-| Weak Crypto | CWE-327 | 278-646 | Secure communication |
-| Session Fixation | CWE-384 | 177-260 | Session management |
-| Misconfiguration | CWE-16 | 233-748 | Configuration hardening |
-| Logging Gaps | CWE-778 | 842-876 | Logging and error handling |
-
-Expand this table as new plays are added. Use the API to discover CRE mappings for CWEs not listed here.
+Then create a new `CWE-XXX.md` file following the existing format.


### PR DESCRIPTION
## Summary

Restructures `data/opencre/` to match the `data/asvs/` and `data/llm-top10/` file format:

- **13 per-CWE files** (`CWE-16.md` through `CWE-798.md`) with YAML frontmatter including `when_to_use` triggers, `threats`, and verified `opencre_mappings`
- **All CRE IDs verified** against the OpenCRE REST API (`GET /rest/v1/standard/CWE/sectionid/{id}`), fixing several incorrect parent-category IDs from the original inline table
- **README rewritten** with mapping index table, API reference, CRE hierarchy, and instructions for adding new CWE mappings

### CWEs Covered

| CWE | Risk | Primary CRE |
|-----|------|-------------|
| CWE-79 | XSS | 366-835 |
| CWE-89 | SQL Injection | 732-873 |
| CWE-78 | Command Injection | 857-718 |
| CWE-22 | Path Traversal | 675-168 |
| CWE-287 | Auth Failures | 813-610 |
| CWE-200 | Info Exposure | 227-045 |
| CWE-327 | Weak Crypto | 742-431 |
| CWE-352 | CSRF | 464-084 |
| CWE-384 | Session Fixation | 002-630 |
| CWE-502 | Deserialization | 831-563 |
| CWE-778 | Logging Gaps | 184-284 |
| CWE-798 | Hardcoded Creds | 774-888 |
| CWE-16 | Misconfiguration | 180-488 |

## Test plan

- [ ] Verify YAML frontmatter parses on all 13 CWE files
- [ ] Spot-check CRE IDs against https://www.opencre.org/cre/{id}
- [ ] Confirm README index links resolve to correct files

🤖 Generated with [Claude Code](https://claude.com/claude-code)